### PR TITLE
feat: parse req body json, set event requestContext and always genera…

### DIFF
--- a/src/express/start-dev-server.ts
+++ b/src/express/start-dev-server.ts
@@ -47,7 +47,7 @@ export async function startDevServer(init: DevServerInit): Promise<void> {
 
   const app = express();
 
-  app.use(express.text());
+  app.use(express.json());
 
   const port = await getPort({port: requestedPort});
   const stackConfig = appConfig.createStackConfig(port);

--- a/src/express/utils/create-lambda-request-handler.ts
+++ b/src/express/utils/create-lambda-request-handler.ts
@@ -41,6 +41,13 @@ export function createLambdaRequestHandler(
           environment,
           event: {
             ...getRequestHeaders(req),
+            requestContext: {
+              protocol: req.protocol,
+              httpMethod: req.method,
+              path: req.path,
+              stage: `$default`,
+              resourcePath: req.path,
+            },
             path: req.path,
             httpMethod: req.method,
             queryStringParameters,

--- a/src/express/utils/get-request-headers.ts
+++ b/src/express/utils/get-request-headers.ts
@@ -7,13 +7,13 @@ export function getRequestHeaders(
   const headers: Record<string, string> = {};
   const multiValueHeaders: Record<string, string[]> = {};
 
-  for (const [key, value] of Object.entries(req.headers)) {
-    if (Array.isArray(value)) {
-      multiValueHeaders[key] = value;
-    } else if (typeof value === `string`) {
-      headers[key] = value;
+  Object.entries(req.headers).forEach(([key, value]) => {
+    if (value) {
+      const multiValue = [value].flat();
+      multiValueHeaders[key] = multiValue;
+      headers[key] = multiValue[multiValue.length - 1] || ``;
     }
-  }
+  });
 
   return {headers, multiValueHeaders};
 }

--- a/src/lambda-local.d.ts
+++ b/src/lambda-local.d.ts
@@ -6,8 +6,9 @@ declare module 'lambda-local' {
   } from 'aws-lambda';
   import type {Logger} from 'winston';
 
+  type DeepPartial<T extends {}> = {[k in keyof T]?: DeepPartial<T[k]>};
   export interface LambdaLocalExecuteOptions {
-    readonly event?: Partial<APIGatewayProxyEvent>;
+    readonly event?: DeepPartial<APIGatewayProxyEvent>;
     readonly environment?: {readonly [key: string]: string};
     readonly lambdaPath?: string;
     readonly lambdaFunc?: ProxyHandler;


### PR DESCRIPTION
To support Apollo-Server-Lambda, we enabled parse req body json, set the event requestContext and make sure to always generate / copy multiValueHeader values