### PR TITLE
Disable Cloudwatch role creation (A40-2701)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adac-de/aws-simple",
-  "version": "18.0.3",
+  "version": "18.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adac-de/aws-simple",
-      "version": "18.0.3",
+      "version": "18.5.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.347.1",

--- a/src/cdk/create-rest-api.ts
+++ b/src/cdk/create-rest-api.ts
@@ -47,6 +47,7 @@ export function createRestApi(
     description: `https://${domainName}`,
     endpointTypes: [aws_apigateway.EndpointType.REGIONAL],
     restApiName: `${getNormalizedName(domainName)}-${getHash(domainName)}`,
+    cloudWatchRole: false,
     domainName: {
       endpointType: aws_apigateway.EndpointType.REGIONAL,
       domainName,


### PR DESCRIPTION
This PR disables the creation of IAM roles when creating an API Gateway which is needed to log to Cloudwatch.